### PR TITLE
build(ci): update install action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           workspaces: ./src-tauri -> target
 
-      - uses: taiki-e/install-action@v2.87.2
+      - uses: taiki-e/install-action@v2.87.7
         with:
           tool: cargo-nextest,cargo-machete
 
@@ -116,7 +116,7 @@ jobs:
         with:
           workspaces: ./src-tauri -> target
 
-      - uses: taiki-e/install-action@v2.87.2
+      - uses: taiki-e/install-action@v2.87.7
         with:
           tool: cargo-nextest
 
@@ -153,7 +153,7 @@ jobs:
           workspaces: ./src-tauri -> target
           key: coverage
 
-      - uses: taiki-e/install-action@v2.87.2
+      - uses: taiki-e/install-action@v2.87.7
         with:
           tool: cargo-llvm-cov,cargo-nextest
 

--- a/src/modules/i18n/locales/en.ts
+++ b/src/modules/i18n/locales/en.ts
@@ -4243,7 +4243,6 @@ export const en = {
     renamedFrom: "(← {path})",
     staged: "Staged",
     unstaged: "Unstaged",
-    renamedFrom: "(← {path})",
     noResults: "No matching files found.",
     allChanges: "All Changes",
     stageAll: "Stage All",

--- a/src/modules/i18n/locales/es.ts
+++ b/src/modules/i18n/locales/es.ts
@@ -4340,7 +4340,6 @@ export const es: TranslationSchema = {
     renamedFrom: "(← {path})",
     staged: "Preparados",
     unstaged: "Sin preparar",
-    renamedFrom: "(← {path})",
     noResults: "No se encontraron archivos coincidentes.",
     allChanges: "Todos los cambios",
     stageAll: "Preparar todo",


### PR DESCRIPTION
Rebuilds Dependabot PR #22 on current main.

Updates taiki-e/install-action from v2.87.2 to v2.87.7 in the CI workflow. Also removes the duplicate renamed-file i18n keys currently preventing main from type-checking.

Validated locally:
- pnpm check-types
- pnpm lint
- pnpm test